### PR TITLE
Video - start time

### DIFF
--- a/demo/quasar.conf.js
+++ b/demo/quasar.conf.js
@@ -18,7 +18,7 @@ module.exports = function (ctx) {
       'eva-icons',
       'themify'
     ],
-    supportIE: false,
+    supportIE: true,
     build: {
       scopeHoisting: true,
       vueRouterMode: 'history',

--- a/demo/src/components/ExampleCard.vue
+++ b/demo/src/components/ExampleCard.vue
@@ -94,7 +94,8 @@ export default {
     VideoTracks: () => import('../examples/VideoTracks'),
     VideoTrackLanguage: () => import('../examples/VideoTrackLanguage'),
     VideoLanguage: () => import('../examples/VideoLanguage'),
-    VideoIconSet: () => import('../examples/VideoIconSet')
+    VideoIconSet: () => import('../examples/VideoIconSet'),
+    VideoStartTime: () => import('../examples/VideoStartTime')
   },
 
   props: {

--- a/demo/src/examples/VideoStartTime.vue
+++ b/demo/src/examples/VideoStartTime.vue
@@ -1,0 +1,21 @@
+<template>
+  <q-media-player
+    type="video"
+    :sources="sources"
+  />
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      sources: [
+        {
+          src: 'https://ftp.nluug.nl/pub/graphics/blender/demo/movies/ToS/ToS-4k-1920.mov#t=30',
+          type: 'video/mp4'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/demo/src/pages/Examples.vue
+++ b/demo/src/pages/Examples.vue
@@ -86,6 +86,13 @@ Not all languages have been translated. If you can help out, please [PR a langua
 > QMediaPlayer does not have a property to set the icon set directly. It uses Quasar's internal icon set support indirectly. When that switches, then QMediaPlayer also switches to that icon set.
       </q-markdown>
       <example-card title="Video - Icon Set" name="VideoIconSet" :tag-parts="getTagParts(require('!!raw-loader!../examples/VideoIconSet.vue').default)" />
+
+      <example-title title="Video - start time" />
+      <q-markdown>
+> You can define the audio/video start using a `#t=` parameter. Example: `ToS-4k-1920.mov#t=30` to start at time 00:30.
+      </q-markdown>
+      <example-card title="Video - Start time" name="VideoStartTime" :tag-parts="getTagParts(require('!!raw-loader!../examples/VideoStartTime.vue').default)" />
+
     </div>
     <q-page-scroller position="bottom-right" :scroll-offset="150" :offset="[18, 18]">
       <q-btn fab icon="keyboard_arrow_up" color="primary" />

--- a/src/component/QMediaPlayer.js
+++ b/src/component/QMediaPlayer.js
@@ -676,6 +676,7 @@ export default function (ssrContext) {
           this.$emit('abort')
         } else if (event.type === 'canplay') {
           this.state.playReady = true
+          this.state.displayTime = timeParse(this.$media.currentTime)
           this.__mouseEnterVideo()
           this.$emit('ready')
         } else if (event.type === 'canplaythrough') {


### PR DESCRIPTION
HTML5 video/audio supports among others parameter `#t=`  for start time. 
- If it was used time in the control panel was not updated.
- IE11 ignores start time. Always starts at 00:00.
- Example was added

Current documentation on the website doesn't support IE. `supportIE` was changed to `true`.
