### PR TITLE
Update current time for start time in file name 

### DIFF
--- a/demo/quasar.conf.js
+++ b/demo/quasar.conf.js
@@ -67,7 +67,7 @@ module.exports = function (/* ctx */) {
     },
 
     // https://quasar.dev/quasar-cli/cli-documentation/supporting-ie
-    supportIE: false,
+    supportIE: true,
 
     // https://quasar.dev/quasar-cli/cli-documentation/supporting-ts
     supportTS: false,

--- a/demo/src/examples/VideoStartTime.vue
+++ b/demo/src/examples/VideoStartTime.vue
@@ -1,0 +1,21 @@
+<template>
+  <q-media-player
+    :sources="sources"
+    type="video"
+  />
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      sources: [
+        {
+          src: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4#t=90',
+          type: 'video/mp4'
+        }
+      ]
+    }
+  }
+}
+</script>

--- a/demo/src/pages/Examples.vue
+++ b/demo/src/pages/Examples.vue
@@ -115,6 +115,18 @@ In the examples below, when the icon set is changed, you will notice that all me
       </q-markdown>
       <example-viewer title="Audio - Icon Set" file="AudioIconSet" :location-url="locationUrl" :js-paths="jsPaths" :css-paths="cssPaths" />
       <example-viewer title="Video - Icon Set" file="VideoIconSet" :location-url="locationUrl" :js-paths="jsPaths" :css-paths="cssPaths" />
+
+      <example-title title="Video - Start time" />
+      <q-markdown>
+> You can define the audio/video start using a `#t=` parameter. Example: `ElephantsDream.mp4#t=10` to start at time at 01:30.
+::: warning
+Internet Explorer 11 ignores the start time parameter
+:::
+
+      </q-markdown>
+      <example-viewer title="Video - Start time" file="VideoStartTime" :location-url="locationUrl" :js-paths="jsPaths" :css-paths="cssPaths" />
+
+      <div style="height: 100px"><!-- do not cover arrow up button for the last example when the right drawer is opened --></div>
     </div>
     <q-page-scroller position="bottom-right" :scroll-offset="150" :offset="[18, 18]">
       <q-btn

--- a/ui/src/components/QMediaPlayer.js
+++ b/ui/src/components/QMediaPlayer.js
@@ -819,6 +819,7 @@ export default {
         this.$emit('abort')
       } else if (event.type === 'canplay') {
         this.state.playReady = true
+        this.state.displayTime = timeParse(this.$media.currentTime)
         this.__mouseEnterVideo()
         this.$emit('ready')
       } else if (event.type === 'canplaythrough') {


### PR DESCRIPTION
HTML5 video/audio supports among others parameter #t= for start time.

- Update the current time in control panel when `#t=` is used.
- IE11 ignores the start time. Always starts at 00:00.
- New video example for start time (can be removed).
- Current documentation on the website doesn't support IE. `supportIE` in `quasar.conf.js` was changed to true.