### PR TITLE
feat(ui): add mdi-v5, svg-mdi-v5, svg-material-icons iconsets

### DIFF
--- a/ui/src/components/icon-set/mdi-v5.js
+++ b/ui/src/components/icon-set/mdi-v5.js
@@ -1,0 +1,17 @@
+export default {
+  name: 'mdi-v5',
+  mediaPlayer: {
+    play: 'mdi-play',
+    pause: 'mdi-pause',
+    volumeOff: 'mdi-volume-off',
+    volumeDown: 'mdi-volume-medium',
+    volumeUp: 'mdi-volume-high',
+    settings: 'mdi-cog',
+    speed: 'mdi-run',
+    language: 'mdi-closed-caption',
+    selected: 'mdi-check',
+    fullscreen: 'mdi-fullscreen',
+    fullscreenExit: 'mdi-fullscreen-exit',
+    bigPlayButton: 'mdi-play'
+  }
+}

--- a/ui/src/components/icon-set/svg-material-icons.js
+++ b/ui/src/components/icon-set/svg-material-icons.js
@@ -1,0 +1,31 @@
+import {
+  matPlayArrow,
+  matPause,
+  matVolumeOff,
+  matVolumeDown,
+  matVolumeUp,
+  matSettings,
+  matDirectionsRun,
+  matClosedCaption,
+  matCheck,
+  matFullscreen,
+  matFullscreenExit
+} from '@quasar/extras/material-icons'
+
+export default {
+  name: 'material-icons',
+  mediaPlayer: {
+    play: matPlayArrow,
+    pause: matPause,
+    volumeOff: matVolumeOff,
+    volumeDown: matVolumeDown,
+    volumeUp: matVolumeUp,
+    settings: matSettings,
+    speed: matDirectionsRun,
+    language: matClosedCaption,
+    selected: matCheck,
+    fullscreen: matFullscreen,
+    fullscreenExit: matFullscreenExit,
+    bigPlayButton: matPlayArrow
+  }
+}

--- a/ui/src/components/icon-set/svg-mdi-v5.js
+++ b/ui/src/components/icon-set/svg-mdi-v5.js
@@ -1,0 +1,31 @@
+import {
+  mdiPlay,
+  mdiPause,
+  mdiVolumeOff,
+  mdiVolumeMedium,
+  mdiVolumeHigh,
+  mdiCog,
+  mdiRun,
+  mdiClosedCaption,
+  mdiCheck,
+  mdiFullscreen,
+  mdiFullscreenExit
+} from '@quasar/extras/mdi-v5'
+
+export default {
+  name: 'mdi-v5',
+  mediaPlayer: {
+    play: mdiPlay,
+    pause: mdiPause,
+    volumeOff: mdiVolumeOff,
+    volumeDown: mdiVolumeMedium,
+    volumeUp: mdiVolumeHigh,
+    settings: mdiCog,
+    speed: mdiRun,
+    language: mdiClosedCaption,
+    selected: mdiCheck,
+    fullscreen: mdiFullscreen,
+    fullscreenExit: mdiFullscreenExit,
+    bigPlayButton: mdiPlay
+  }
+}


### PR DESCRIPTION
Good day :)

I'm replacing all webfont icons in my app with svg ones and noticed qmediaplayer did not yet come with svg iconsets.
Since the mdi-v4 iconset gave me _weird_ results (most icons didn't show up, and "mdi-play" was completely wrong), I included a mdi-v5 one as well.
The only change to the iconnames being mdi-settings -> mdi-cog.

I used https://material.io/resources/icons/ and https://materialdesignicons.com/ to make sure all the `mdi-v5` icons are equivalent to their `material-icons` counterparts.

I tested with the demo running locally and confirmed that icons are showing and using svg.

I hope I'm not missing something, let me know what you think.
As always: Thank you for your work!