### PR TITLE
If mediaPlayer is included in current loaded iconSet, doesn't tries to load part of iconSet from this library

### DIFF
--- a/ui/src/components/QMediaPlayer.js
+++ b/ui/src/components/QMediaPlayer.js
@@ -857,14 +857,19 @@ export default defineComponent({
     }
 
     async function __setupIcons () {
-      const iconSetName = $q.iconSet.name || 'material-icons'
-      let icnSet
-      try {
-        icnSet = await __loadIconSet(iconSetName)
+      let icnSet;
+
+      if (typeof $q.iconSet.mediaPlayer === 'object') {
+        icnSet = $q.iconSet;
+      } else {
+        const iconSetName = $q.iconSet.name || 'material-icons';
+
+        try {
+          icnSet = await __loadIconSet(iconSetName);
+        } catch (e) {
+        }
       }
-      catch (e) {
-      }
-      icnSet !== void 0 && icnSet.name !== void 0 && (iconSet.mediaPlayer = { ...icnSet.mediaPlayer })
+      icnSet !== void 0 && icnSet.name !== void 0 && (iconSet.mediaPlayer = { ...icnSet.mediaPlayer });
     }
 
     async function __loadIconSet (set) {


### PR DESCRIPTION
This partially fixes #363 - if `mediaPlayers` icons group is already defined in current iconset uses it, otherwise tries to older iconset loader. logic 