### PR TITLE
Vite: fix esm load path for material-icons

### DIFF
--- a/ui/src/components/QMediaPlayer.js
+++ b/ui/src/components/QMediaPlayer.js
@@ -887,7 +887,7 @@ export default defineComponent({
           try {
             const result = await import (
               /* webpackChunkName: "[request]" */
-              `@quasar/quasar-ui-qmediaplayer/src/components/icon-set/${ set }.js`
+              `./icon-set/${ set }.js`
             )
             iconsList = result.default
           }


### PR DESCRIPTION
This fixed is based on the error that is caught. "@" can't be resolved for some reason:
"The specifier “@quasar/quasar-ui-qmediaplayer/src/components/icon-set/material-icons.js” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”."